### PR TITLE
Added ability to search tags from ImageViewerPage

### DIFF
--- a/src/assets/scripts/Danbooru.js
+++ b/src/assets/scripts/Danbooru.js
@@ -102,6 +102,11 @@ function ParseTagJSON(json) {
     try {
         if (typeof(json) !== typeof(JSON)) json = JSON.parse(json) 
 
+        if (
+            json.post_count != undefined && json.post_count == 0 ||
+            json.is_deprecated != undefined && json.is_deprecated == true
+        ) return null
+
         return {
             Name: json.name,
             DisplayName: json.name.replace("_", " "),

--- a/src/assets/scripts/Safebooru.js
+++ b/src/assets/scripts/Safebooru.js
@@ -102,6 +102,11 @@ function ParseTagJSON(json) {
     try {
         if (typeof(json) !== typeof(JSON)) json = JSON.parse(json) 
 
+        if (
+            json.post_count != undefined && json.post_count == 0 ||
+            json.is_deprecated != undefined && json.is_deprecated == true
+        ) return null
+
         return {
             Name: json.name,
             DisplayName: json.name.replace("_", " "),

--- a/src/lib/classes/extension/types.dart
+++ b/src/lib/classes/extension/types.dart
@@ -41,7 +41,7 @@ enum TagType {
     general, artist, copyright, character, meta, lore, species, invalid,
 }
 
-class Tag extends ExtensionObject {
+class Tag extends ExtensionObject implements Comparable<Tag> {
     String tagName;
     String? tagDisplayOverride;
     TagType type;
@@ -70,8 +70,21 @@ class Tag extends ExtensionObject {
         );
     }
 
+    negate() {
+        if (tagName.startsWith("-")) {
+            tagName = tagName.substring(1);
+        } else {
+            tagName = "-$tagName";
+        }
+    }
+
     @override
     String toString() => tagName;
+    
+    @override
+    int compareTo(Tag other) {
+        return tagName.compareTo(other.tagName) & type.index.compareTo(other.type.index);
+    }
 }
 
 class Tags {

--- a/src/lib/classes/widgets/search_appbar.dart
+++ b/src/lib/classes/widgets/search_appbar.dart
@@ -1,6 +1,7 @@
 import 'package:chips_input/chips_input.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:get_storage/get_storage.dart';
 import 'package:ibuki/classes/extension/types.dart';
 import 'package:ibuki/classes/settings.dart';
 import 'package:ibuki/classes/widgets/tag_widgets.dart';
@@ -20,12 +21,16 @@ class SearchAppBar extends HookWidget implements PreferredSizeWidget {
         required this.settings, 
         required this.onSearch, 
         required this.onSearchClear,
+        this.leading,
         this.title, 
+        this.initialValue,
         this.toolbarHeight, 
         this.bottom, 
     });
     
+    final Widget? leading;
     final String? title;
+    final Tag? initialValue;
     final Settings settings;
     final double? toolbarHeight;
     final PreferredSizeWidget? bottom;
@@ -39,6 +44,10 @@ class SearchAppBar extends HookWidget implements PreferredSizeWidget {
         final search = useState("");
         final searchQuery = useState<List<Tag>>([]);
 
+        if (initialValue != null && searchQuery.value.isEmpty) {
+            // search.value = initialValue!.tagName;
+            searchQuery.value = [initialValue!];
+        }
 
         Future<List<Tag>?> searchTag(String query) async {
             final booru = settings.activeBooru;
@@ -57,7 +66,11 @@ class SearchAppBar extends HookWidget implements PreferredSizeWidget {
         final chipInput = ChipsInput<Tag>(
             chipBuilder: (context, state, tag) => TagChip(
                 key: ObjectKey(tag),
-                tag: tag
+                tag: tag,
+                onPressed: () {
+                    // tag.negate();
+                },
+                onDeleted: () => state.deleteChip(tag),
             ), 
             suggestionBuilder: (context, tag) => TagListTile(
                 key: ObjectKey(tag),
@@ -77,6 +90,7 @@ class SearchAppBar extends HookWidget implements PreferredSizeWidget {
         );
 
         return AppBar(
+            leading: leading,
             title: searchActive.value ? chipInput : Text(search.value.isNotEmpty ? search.value : title ??  ""),
             actions: [
                 IconButton(
@@ -84,7 +98,7 @@ class SearchAppBar extends HookWidget implements PreferredSizeWidget {
                     icon: const Icon(Icons.search)
                 ),
                 Visibility(
-                    visible: search.value.isNotEmpty || searchActive.value,
+                    visible: searchQuery.value.isNotEmpty || search.value.isNotEmpty || searchActive.value,
                     child: IconButton(
                         onPressed: () {
                             searchActive.value = false;

--- a/src/lib/classes/widgets/tag_widgets.dart
+++ b/src/lib/classes/widgets/tag_widgets.dart
@@ -116,18 +116,24 @@ class TagListTile extends ListTile {
 class TagChip extends StatelessWidget {
     final Tag tag;
     final TagTheme? theme;
+    final VoidCallback? onPressed;
+    final VoidCallback? onDeleted;
 
     const TagChip({
         Key? key,
         required this.tag,
+        this.onPressed,
+        this.onDeleted,
         this.theme,
     }) : super(key: key);
     
     _makeChip(Color color) {
-        return Chip(
+        return RawChip(
             label: Text(tag.tagDisplay()),
             backgroundColor: color,
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            onPressed: onPressed,
+            onDeleted: onDeleted,
         );
     }
 
@@ -161,8 +167,9 @@ class TagChip extends StatelessWidget {
 class TagsList extends StatelessWidget {
     final String title;
     final List<Tag>? tags;
+    final void Function(Tag)? onTagPressed;
 
-    const TagsList({super.key, required this.title, required this.tags});
+    const TagsList({super.key, required this.title, required this.tags, this.onTagPressed});
 
     @override
     Widget build(BuildContext context) {
@@ -181,7 +188,7 @@ class TagsList extends StatelessWidget {
                         alignment: WrapAlignment.start, 
                         spacing: 8, 
                         runSpacing: 8, 
-                        children: tags?.map((tag) => TagChip(tag: tag)).toList() ?? []
+                        children: tags?.map((tag) => TagChip(tag: tag, onPressed: () => onTagPressed?.call(tag))).toList() ?? []
                     )
                 )
             ]


### PR DESCRIPTION
The implementation is quite questionable and honestly looks like a house of cards to me. If anybody will be able to come up with a better solution - hit me up or just create a pull request/suggest something in the Issues section.
The base `MainPage` (the one you see, when the app is first opened) will never have `searchRequest` parameter set to anything other than `null`, so we have a solid base there to pop back into. Tapping on a tag will push `MainPage` with `searchRequest` being set, producing a stack of searches. About the fact that the tag being searched is not the base one will remind `IconButton` with `Icons.arrow_back`.

- [x] Added tapping/deleting events to TagChip
- [x] Implemented search by tapping on a tag in a `Viewer`
- [x] Replaced call to settings with active Booru index to call to getter from `activeBooruId`
- [x] Settings are now accessible through all the pages (so that `Viewer` can call `MainPage`)
- [x] Added `Comparable<Tag>` implementation for `Tag` (although, I'm not sure why for now, the idea was to compare tags in `ChipsInput` box when a tag search is called...)
- [x] Added ability to negate a tag (needs more work, since only negates a tag internally for now...)