### PR TITLE
Fixed crash on Android API 33 with permissions

### DIFF
--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 // import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:get_storage/get_storage.dart';
@@ -14,14 +15,17 @@ void main() async {
     await settings.init(null);
 
     if (Platform.isAndroid) {
-        Map<Permission, PermissionStatus> statuses = await [
-            Permission.storage,
-            //add more permission to request here.
-        ].request();
+        AndroidDeviceInfo androidInfo = await DeviceInfoPlugin().androidInfo;
+        if (androidInfo.version.sdkInt < 33) {
+            Map<Permission, PermissionStatus> statuses = await [
+                Permission.storage,
+                //add more permission to request here.
+            ].request();
 
-        if (!statuses[Permission.storage]!.isGranted) {
-            debugPrint("Permission denied.");
-            exit(1);
+            if (!statuses[Permission.storage]!.isGranted) {
+                debugPrint("Permission denied.");
+                exit(1);
+            }
         }
     }
 

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -97,6 +97,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: f52ab3b76b36ede4d135aab80194df8925b553686f0fa12226b4e2d658e45903
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   dio:
     dependency: "direct main"
     description:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   window_manager: ^0.3.4
 #   flutter_acrylic: ^1.1.0
   visibility_detector: ^0.4.0+2
+  device_info_plus: ^8.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes #7.

- [x] Added dependency `device_info_plus`
- [x] Added check for current Android API version